### PR TITLE
Remove need for C.GoBytes & gcc on windows

### DIFF
--- a/native.go
+++ b/native.go
@@ -1,7 +1,6 @@
 package wincred
 
 import (
-	"C"
 	"syscall"
 	"unsafe"
 )


### PR DESCRIPTION
 By just copying the bytes with a local goBytes function, we can avoid needing a dependency on `C`, which means you can now build this module without `gcc` being installed on Windows.