### PR TITLE
Add windows build tags

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package wincred
 
 import (

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package wincred
 
 import (

--- a/native.go
+++ b/native.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package wincred
 
 import (

--- a/native_test.go
+++ b/native_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package wincred
 
 import (

--- a/wincred.go
+++ b/wincred.go
@@ -1,3 +1,5 @@
+// +build windows
+
 // Package wincred provides primitives for accessing the Windows Credentials Management API.
 // This includes functions for retrieval, listing and storage of credentials as well as Go structures for convenient access to the credential data.
 //

--- a/wincred_test.go
+++ b/wincred_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package wincred
 
 import (


### PR DESCRIPTION
This avoids compilation errors on other platforms.

Closes https://github.com/danieljoos/wincred/issues/8