### PR TITLE
Check error codes not strings (fix non-english locales)

### DIFF
--- a/sys_unsupported.go
+++ b/sys_unsupported.go
@@ -4,17 +4,6 @@ package wincred
 
 import "errors"
 
-const (
-	sysCRED_TYPE_GENERIC                 = 0
-	sysCRED_TYPE_DOMAIN_PASSWORD         = 0
-	sysCRED_TYPE_DOMAIN_CERTIFICATE      = 0
-	sysCRED_TYPE_DOMAIN_VISIBLE_PASSWORD = 0
-	sysCRED_TYPE_GENERIC_CERTIFICATE     = 0
-	sysCRED_TYPE_DOMAIN_EXTENDED         = 0
-
-	sysERROR_NOT_FOUND = ""
-)
-
 func sysCredRead(...interface{}) (*Credential, error) {
 	return nil, errors.New("Operation not supported")
 }


### PR DESCRIPTION
Checking the error string fails for non-english locales.

You can check the syscall.Errno (uint) against the error code for ERROR_NOT_FOUND, etc.