### PR TITLE
Uses error codes instead of error strings

### DIFF
--- a/sys.go
+++ b/sys.go
@@ -58,7 +58,9 @@ const (
 	sysCRED_TYPE_GENERIC_CERTIFICATE     sysCRED_TYPE = 0x5
 	sysCRED_TYPE_DOMAIN_EXTENDED         sysCRED_TYPE = 0x6
 
-	sysERROR_NOT_FOUND = "Element not found."
+	// https://docs.microsoft.com/en-us/windows/desktop/Debug/system-error-codes
+	sysERROR_NOT_FOUND         = syscall.Errno(1168)
+	sysERROR_INVALID_PARAMETER = syscall.Errno(87)
 )
 
 // https://docs.microsoft.com/en-us/windows/desktop/api/wincred/nf-wincred-credreadw

--- a/wincred.go
+++ b/wincred.go
@@ -5,6 +5,19 @@
 // Docs: https://docs.microsoft.com/en-us/windows/desktop/SecAuthN/credentials-management
 package wincred
 
+import "errors"
+
+const (
+	// ErrElementNotFound is the error that is returned if a requested element cannot be found.
+	// This error constant can be used to check if a credential could not be found.
+	ErrElementNotFound = sysERROR_NOT_FOUND
+
+	// ErrInvalidParameter is the error that is returned for invalid parameters.
+	// This error constant can be used to check if the given function parameters were invalid.
+	// For example when trying to create a new generic credential with an empty target name.
+	ErrInvalidParameter = sysERROR_INVALID_PARAMETER
+)
+
 // GetGenericCredential fetches the generic credential with the given name from Windows credential manager.
 // It returns nil and an error if the credential could not be found or an error occurred.
 func GetGenericCredential(targetName string) (*GenericCredential, error) {
@@ -77,7 +90,7 @@ func (t *DomainPassword) SetPassword(pw string) {
 // List retrieves all credentials of the Credentials store.
 func List() ([]*Credential, error) {
 	creds, err := sysCredEnumerate("", true)
-	if err != nil && err.Error() == sysERROR_NOT_FOUND {
+	if err != nil && errors.Is(err, ErrElementNotFound) {
 		// Ignore ERROR_NOT_FOUND and return an empty list instead
 		creds = []*Credential{}
 		err = nil
@@ -89,7 +102,7 @@ func List() ([]*Credential, error) {
 // The filter string defines the prefix followed by an asterisk for the `TargetName` attribute of the credentials.
 func FilteredList(filter string) ([]*Credential, error) {
 	creds, err := sysCredEnumerate(filter, false)
-	if err != nil && err.Error() == sysERROR_NOT_FOUND {
+	if err != nil && errors.Is(err, ErrElementNotFound) {
 		// Ignore ERROR_NOT_FOUND and return an empty list instead
 		creds = []*Credential{}
 		err = nil

--- a/wincred_test.go
+++ b/wincred_test.go
@@ -3,6 +3,7 @@
 package wincred
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,34 +70,26 @@ func TestGetGenericCredential_NotFound(t *testing.T) {
 	cred, err := GetGenericCredential(testTargetNameMissing)
 	assert.Nil(t, cred)
 	assert.NotNil(t, err)
-	// ERROR_NOT_FOUND (1168):
-	// Docs: https://docs.microsoft.com/en-us/windows/desktop/Debug/system-error-codes--1000-1299-
-	assert.Equal(t, "Element not found.", err.Error())
+	assert.True(t, errors.Is(err, ErrElementNotFound))
 }
 
 func TestGetGenericCredential_Empty(t *testing.T) {
 	cred, err := GetGenericCredential("")
 	assert.Nil(t, cred)
 	assert.NotNil(t, err)
-	// ERROR_INVALID_PARAMETER (87):
-	// Docs: https://docs.microsoft.com/en-us/windows/desktop/Debug/system-error-codes--0-499-
-	assert.Equal(t, "The parameter is incorrect.", err.Error())
+	assert.True(t, errors.Is(err, ErrInvalidParameter))
 }
 
 func TestGenericCredential_WriteEmpty(t *testing.T) {
 	cred := NewGenericCredential("")
 	err := cred.Write()
 	assert.NotNil(t, err)
-	// ERROR_INVALID_PARAMETER (87):
-	// Docs: https://docs.microsoft.com/en-us/windows/desktop/Debug/system-error-codes--0-499-
-	assert.Equal(t, "The parameter is incorrect.", err.Error())
+	assert.True(t, errors.Is(err, ErrInvalidParameter))
 }
 
 func TestGenericCredential_DeleteNotFound(t *testing.T) {
 	cred := NewGenericCredential(testTargetNameMissing)
 	err := cred.Delete()
 	assert.NotNil(t, err)
-	// ERROR_NOT_FOUND (1168):
-	// Docs: https://docs.microsoft.com/en-us/windows/desktop/Debug/system-error-codes--1000-1299-
-	assert.Equal(t, "Element not found.", err.Error())
+	assert.True(t, errors.Is(err, ErrElementNotFound))
 }


### PR DESCRIPTION
This may fix issues for non-english systems that do not produce english
error messages.