### PR TITLE
Allocate CREDENTIALW struct before reading

### DIFF
--- a/sys.go
+++ b/sys.go
@@ -65,7 +65,7 @@ const (
 
 // https://docs.microsoft.com/en-us/windows/desktop/api/wincred/nf-wincred-credreadw
 func sysCredRead(targetName string, typ sysCRED_TYPE) (*Credential, error) {
-	var pcred *sysCREDENTIAL
+	pcred := &sysCREDENTIAL{}
 	targetNamePtr, _ := syscall.UTF16PtrFromString(targetName)
 	ret, _, err := procCredRead.Call(
 		uintptr(unsafe.Pointer(targetNamePtr)),


### PR DESCRIPTION
CredReadW documentation says for the "Credential" argument:

> Pointer to a single allocated block buffer to return the credential. Any pointers contained within the buffer are pointers to locations within this single allocated block. The single returned buffer must be freed by calling CredFree.

This tries to allocate memory for a single CREDENTIALW struct before dispatching the syscall that reads data into the struct.

I'm not sure of this solution or if it even makes sense, since I'm not really proficient in win32 C APIs, but I have successfully applied this patch to GitHub CLI to stop crashes due to GetGenericCredential returning `(nil, nil)`.

Fixes https://github.com/danieljoos/wincred/issues/32